### PR TITLE
Remove things from startup path for perf sake

### DIFF
--- a/src/dotnet-cs/Program.cs
+++ b/src/dotnet-cs/Program.cs
@@ -278,7 +278,7 @@ async Task<int> RunCommand(ParseResult parseResult, CancellationToken cancellati
     }
 
     var fd = RuntimeInformation.FrameworkDescription;
-    if (!fd.StartsWith(".NET 10.0", StringComparison.OrdinalIgnoreCase))
+    if (!(fd.StartsWith(".NET 10.", StringComparison.OrdinalIgnoreCase) || fd.StartsWith(".NET 11.", StringComparison.OrdinalIgnoreCase)))
     {
         var (hasMinRequiredSdkVersion, minimumSdkVersion, currentSdkVersion) = await ValidateMinimumSdkVersion(new SemanticVersion(10, 0, 100, "preview.3.25163.13"), cancellationToken);
         if (!hasMinRequiredSdkVersion)

--- a/src/dotnet-cs/Properties/launchSettings.json
+++ b/src/dotnet-cs/Properties/launchSettings.json
@@ -4,8 +4,8 @@
       "commandName": "Project",
       //"commandLineArgs": "https://raw.githubusercontent.com/DamianEdwards/csrun/refs/heads/main/samples/hello.cs"
       //"commandLineArgs": "-"
-      "commandLineArgs": "..\\..\\samples\\hello.cs --edit",
-      "workingDirectory": "$(ProjectDir)"
+      "commandLineArgs": "hello.cs",
+      "workingDirectory": "$(ProjectDirectory)..\\..\\samples"
     }
   }
 }

--- a/src/dotnet-cs/dotnet-cs.csproj
+++ b/src/dotnet-cs/dotnet-cs.csproj
@@ -9,7 +9,7 @@
     <Nullable>enable</Nullable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>cs</ToolCommandName>
-    <VersionPrefix>0.0.8</VersionPrefix>
+    <VersionPrefix>0.0.9</VersionPrefix>
     <VersionSuffix Condition=" '$(Configuration)' == 'Debug' ">dev</VersionSuffix>
     <Authors>Damian Edwards</Authors>
     <Copyright>Copyright © Damian Edwards</Copyright>


### PR DESCRIPTION
Reorganized some things to avoid startup time perf hit. Was seeing ~200ms overhead of using `cs hello.cs` vs. `dotnet run hello.cs` and these changes basically remove that.

Min SDK version check doesn't happen now unless the runtime description version indicates the runtime isn't .NET 10 or .NET 11