### PR TITLE
Implement build caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,16 @@ cs [<APPARGS>...] < <CSFILE>
 Name  | Description
 ------|------------------------------------------------
 `<TARGETAPPFILE>` | The file path or URI for the C# file to run. Pass '-' to enter interactive terminal mode.
-`<APPARGS>` | Any arguments that should be passed to the C# app.
+`<APPARGS>` | Any arguments that should be passed to the C# app
 
 ### Options
 
 Name  | Description
 ------|------------------------------------------------
-`-?`, `-h`, `--help` | Show help information.
-`--version` | Show version information.
+`-?`, `-h`, `--help` | Show help information
+`--version` | Show version information
 `--edit` | Edit content in an interactive terminal C# editor
-
+`--no-cache` | Do not use the cache file to determine if the target file is up to date
 
 ### Examples
 

--- a/src/dotnet-cs/Program.cs
+++ b/src/dotnet-cs/Program.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Net.Http.Json;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Security.AccessControl;
 using System.Text;
 using System.Text.Json.Serialization;
 using DotNetCs;
@@ -30,10 +31,15 @@ var editOption = new Option<bool>("--edit")
     Description = "Edit content in an interactive terminal C# editor"
 };
 
+var noCacheOption = new Option<bool>("--no-cache")
+{
+    Description = "Do not use the cache file to determine if the target file is up to date"
+};
+
 #if DEBUG
 var debugOption = new Option<bool>("--debug", "-d")
 {
-    Description = "Enable debug mode.",
+    Description = "Enable debug mode",
     Hidden = true
 };
 #endif
@@ -43,6 +49,7 @@ var rootCommand = new RootCommand("Runs C# from a file, URI, or stdin")
     targetArgument,
     appArgsArgument,
     editOption,
+    noCacheOption,
 #if DEBUG
     debugOption
 #endif
@@ -78,6 +85,7 @@ async Task<int> RunCommand(ParseResult parseResult, CancellationToken cancellati
     var targetValue = parseResult.GetValue(targetArgument);
     var appArgsValue = parseResult.GetValue(appArgsArgument);
     var editOptionValue = parseResult.GetValue(editOption);
+    var noCacheOptionValue = parseResult.GetValue(noCacheOption);
     var canEdit = !Console.IsInputRedirected && (editOptionValue || targetValue == "-");
     var canSave = false;
     var saveToTempFileOnRun = false;
@@ -290,7 +298,7 @@ async Task<int> RunCommand(ParseResult parseResult, CancellationToken cancellati
     }
 
     // Run the target file
-    var exitCode = await DotnetCli.Run(targetFilePath!, appArgs, cancellationToken);
+    var exitCode = await DotnetCli.Run(targetFilePath!, appArgs, noCacheOptionValue, cancellationToken);
 
     // Process the detect newer version task
     try
@@ -427,12 +435,20 @@ static class DotnetCli
         return SemanticVersion.TryParse(stdout.ToString().Trim(), out var value) ? value : null;
     }
 
-    public async static Task<int> Run(string filePath, List<string>? args, CancellationToken cancellationToken)
+    public async static Task<int> Run(string filePath, List<string>? args, bool disableCache, CancellationToken cancellationToken)
     {
-        var arguments = RunArgs.Concat([filePath]);
+        var arguments = new List<string>(RunArgs)
+        {
+            filePath
+        };
+        if (!disableCache && UpToDate(filePath))
+        {
+            arguments.Add("--no-build");
+        }
         if (args is { Count: > 0 })
         {
-            arguments = arguments.Concat(args);
+            arguments.Add("--");
+            arguments.AddRange(args);
         }
         var startInfo = GetProcessStartInfo(arguments);
         startInfo.CreateNoWindow = false;
@@ -442,6 +458,85 @@ static class DotnetCli
         await process.WaitForExitAsync(cancellationToken);
 
         return process.ExitCode;
+    }
+
+    private static bool UpToDate(string filePath)
+    {
+        var fileInfo = new FileInfo(filePath);
+        var cacheFileInfo = new FileInfo(fileInfo.FullName + ".csrun.cache");
+        var upToDate = true;
+
+        if (!cacheFileInfo.Exists)
+        {
+            // Create the cache sentinel file if it doesn't exist
+            try
+            {
+                // Write the cache sentinel file
+                File.WriteAllText(cacheFileInfo.FullName, string.Empty);
+                File.SetLastWriteTimeUtc(cacheFileInfo.FullName, DateTime.UtcNow);
+                File.SetAttributes(cacheFileInfo.FullName, FileAttributes.Hidden);                
+            }
+            catch (Exception)
+            {
+                // Ignore any failures when trying to create the cache file
+            }
+            upToDate = false;
+        }
+
+        // Check if file was modified since last run
+        if (upToDate && fileInfo.LastWriteTimeUtc > cacheFileInfo.LastWriteTimeUtc)
+        {
+            // Update the cache file's last write time to the current time
+            try
+            {
+                File.SetLastWriteTimeUtc(cacheFileInfo.FullName, DateTime.UtcNow);
+            }
+            catch (Exception)
+            {
+                // Ignore any failures when trying to update the cache file's last write time
+            }
+            return false;
+        }
+
+        // Check if implicit build files exist and are up to date since last run.
+        // Implicit build files include Directory.Build.props, Directory.Build.targets, Directory.Packages.props, and global.json.
+        // These files are usually located in the same directory as the target file or in parent directories.
+        // If any of these files are newer than the target file, we should rebuild the project.
+        var implicitBuildFiles = new[] { "Directory.Build.props", "Directory.Build.targets", "Directory.Packages.props", "global.json" };
+        var directory = fileInfo.Directory;
+
+        while (directory != null)
+        {
+            foreach (var implicitFileName in implicitBuildFiles)
+            {
+                var implicitFilePath = Path.Combine(directory.FullName, implicitFileName);
+                if (File.Exists(implicitFilePath))
+                {
+                    var implicitFileInfo = new FileInfo(implicitFilePath);
+                    var implicitCacheFileInfo = new FileInfo(implicitFileInfo.FullName + ".csrun.cache");
+
+                    if (!implicitCacheFileInfo.Exists || implicitFileInfo.LastWriteTimeUtc > implicitCacheFileInfo.LastWriteTimeUtc)
+                    {
+                        // Create or update the cache sentinel file
+                        try
+                        {
+                            File.WriteAllText(implicitCacheFileInfo.FullName, string.Empty);
+                            File.SetAttributes(implicitCacheFileInfo.FullName, FileAttributes.Hidden);
+                            File.SetLastWriteTimeUtc(implicitCacheFileInfo.FullName, DateTime.UtcNow);
+                        }
+                        catch (Exception)
+                        {
+                            // Ignore any failures when trying to create or update the cache file
+                        }
+                        upToDate = false;
+                    }
+                }
+            }
+
+            directory = directory.Parent; // Move to the parent directory
+        }
+
+        return upToDate;
     }
 
     private static Process Start(IEnumerable<string> arguments) => Start(GetProcessStartInfo(arguments));

--- a/src/dotnet-cs/dotnet-cs.csproj
+++ b/src/dotnet-cs/dotnet-cs.csproj
@@ -9,7 +9,7 @@
     <Nullable>enable</Nullable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>cs</ToolCommandName>
-    <VersionPrefix>0.0.9</VersionPrefix>
+    <VersionPrefix>0.0.10</VersionPrefix>
     <VersionSuffix Condition=" '$(Configuration)' == 'Debug' ">dev</VersionSuffix>
     <Authors>Damian Edwards</Authors>
     <Copyright>Copyright © Damian Edwards</Copyright>


### PR DESCRIPTION
Hidden cache sentinel files are created and checked on run now so that build can be avoided when things are up to date still from the last run. Build is avoiding by passing `--no-build` to the underlying `dotnet run file.cs` command. The C# file and applicable implicit build files are considered (`Directory.Build.props`, `Directory.Build.targets`, `Directory.Packages.props`, and `global.json`).

Fixes #16