### PR TITLE
Add a timeout when checking for a new version & only check once per hour

### DIFF
--- a/src/dotnet-cs/Program.cs
+++ b/src/dotnet-cs/Program.cs
@@ -303,7 +303,7 @@ async Task<int> RunCommand(ParseResult parseResult, CancellationToken cancellati
     // Process the detect newer version task
     try
     {
-        var newerVersion = await detectNewerVersionTask;
+        var newerVersion = await detectNewerVersionTask.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
         if (newerVersion is not null)
         {
             // TODO: Handle case when newer version is a pre-release version

--- a/src/dotnet-cs/dotnet-cs.csproj
+++ b/src/dotnet-cs/dotnet-cs.csproj
@@ -9,7 +9,7 @@
     <Nullable>enable</Nullable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>cs</ToolCommandName>
-    <VersionPrefix>0.0.10</VersionPrefix>
+    <VersionPrefix>0.0.11</VersionPrefix>
     <VersionSuffix Condition=" '$(Configuration)' == 'Debug' ">dev</VersionSuffix>
     <Authors>Damian Edwards</Authors>
     <Copyright>Copyright © Damian Edwards</Copyright>


### PR DESCRIPTION
Add a timeout so that the tool doesn't pause after app execution waiting for the check for a new version for too long.